### PR TITLE
allow wrapped text in first cells and column headers

### DIFF
--- a/src/__fixtures__/simpleTable.ts
+++ b/src/__fixtures__/simpleTable.ts
@@ -15,7 +15,9 @@ export const simpleTable = `
             Visits
           </th>
           <th id="header-cell-5">
-            Status
+            <div>
+              Status
+            </div>
           </th>
           <th id="header-cell-6">
             Profile Progress
@@ -32,7 +34,7 @@ export const simpleTable = `
           <td id="body-cell-6">52</td>
         </tr>
         <tr id="body-row-2">
-          <td id="body-cell-7">midnight</td>
+          <td id="body-cell-7"><div>midnight</div></td>
           <td id="body-cell-8">sense</td>
           <td id="body-cell-9">22</td>
           <td id="body-cell-10">25</td>

--- a/src/queries.test.ts
+++ b/src/queries.test.ts
@@ -136,6 +136,21 @@ describe('queries', () => {
       'body-cell-33',
       'body-cell-39'
     ])
+    const statusCells = queries.getAllColumnCellsByHeaderText(
+      container,
+      'Status'
+    )
+    expect(statusCells).toHaveLength(8)
+    expect(statusCells.map((cell) => cell.id)).toEqual([
+      'header-cell-5',
+      'body-cell-5',
+      'body-cell-11',
+      'body-cell-17',
+      'body-cell-23',
+      'body-cell-29',
+      'body-cell-35',
+      'body-cell-41'
+    ])
   })
 
   it('should find rows by the first cell text', () => {
@@ -151,6 +166,9 @@ describe('queries', () => {
     )
     expect(queries.getRowByFirstCellText(container, 'First Name').id).toEqual(
       'header-row'
+    )
+    expect(queries.getRowByFirstCellText(container, 'midnight').id).toEqual(
+      'body-row-2'
     )
   })
 

--- a/src/rowByFirstCellText.ts
+++ b/src/rowByFirstCellText.ts
@@ -1,6 +1,5 @@
 import {
   queryHelpers,
-  getNodeText,
   getDefaultNormalizer
 } from '@testing-library/dom'
 import { queryAllRows } from './rows'
@@ -18,7 +17,7 @@ function queryAllRowsByFirstCellText(
     }
 
     // TODO - make normaliser customisable, support textmatch
-    return getDefaultNormalizer()(getNodeText(cellsInRow[0])) === textContent
+    return getDefaultNormalizer()(cellsInRow[0].textContent) === textContent
   })
 }
 

--- a/src/utils/columnIndexByHeaderText.ts
+++ b/src/utils/columnIndexByHeaderText.ts
@@ -22,7 +22,7 @@ export const getColumnIndexByHeaderText = (
 
   const cellIndex = headerRowToUse.findIndex((cell) => {
     // TODO - allow normaliser to be overridden
-    return getDefaultNormalizer()(getNodeText(cell)) === textContent
+    return getDefaultNormalizer()(cell.textContent) === textContent
   })
   if (cellIndex === -1) {
     return -1


### PR DESCRIPTION
Retrieving the text of a cell via `getNodeText` only works if the text is a direct child of the cell node. Retrieving the text using `textContent` also returns text wrapped in child elements.